### PR TITLE
Update regex pinning in meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -38,7 +38,7 @@ requirements:
     - babel ~=2.10
     - colorama ~=0.4
     - paginate ~=0.5
-    - regex ~=2022.4
+    - regex >=2022.4
     - requests ~=2.26
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

I noticed that the regex pinning is incorrect relative to the `mkdocs-material` requirements file since v9.4.2 (see https://github.com/squidfunk/mkdocs-material/commit/43b5baf8a7bf1514c351f90c088ced07710fa95d). This isn't reflected in the conda-forge recipe which causes problems with installing `mkdocs-material` with python 3.12 on macos-arm64 (maybe also on other architectures).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
