### PR TITLE
Fix PiP Check Failure - Match Source Click Limit <8.2.2

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: e1f84d21ec5fb730673c4259b2e0d39f8d32a3fef613e3a8e7094b012d43e790
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv
 
@@ -38,6 +38,10 @@ requirements:
     - paginate >=0.5,<1.dev0
     - backrefs >=5.7.post1,<6.dev0
     - requests >=2.26,<3.dev0
+    # Refer - https://github.com/squidfunk/mkdocs-material/blob/f0b0b5931a386b670c19d3e3b78ecd41da144341/requirements.txt#L36C1-L38C12
+    # Temporarily pin click until this is resolved in MkDocs, see
+    # https://github.com/mkdocs/mkdocs/issues/4014#issuecomment-3146508306
+    - click <8.2.2
 
 tests:
   - python:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
fixes https://github.com/conda-forge/mkdocs-material-feedstock/issues/290
<!--
Please add any other relevant info below:
-->
See pip check failure on 
https://github.com/conda-forge/drf-to-mkdoc-feedstock/pull/5#issuecomment-3321859003